### PR TITLE
Make end portal frames flat in hand

### DIFF
--- a/golden-days-base/assets/minecraft/models/item/end_portal_frame.json
+++ b/golden-days-base/assets/minecraft/models/item/end_portal_frame.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:block/end_portal_frame_side"
+  }
+}


### PR DESCRIPTION
This is to make it looks like how it was in b1.9 according to minecraft wiki
![image](https://user-images.githubusercontent.com/37207067/96644761-cc78fc80-1329-11eb-975b-aeefce3bf12a.png)
