### PR TITLE
Using 1.17 shaders to add grey lighting in vanilla.

### DIFF
--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/particle.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/particle.vsh
@@ -1,0 +1,25 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec2 UV0;
+in vec4 Color;
+in ivec2 UV2;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out float vertexDistance;
+out vec2 texCoord0;
+out vec4 vertexColor;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    texCoord0 = UV0;
+    vertexColor = Color * minecraft_fetch_lightmap(Sampler2, UV2);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_armor_cutout_no_cull.vsh
@@ -1,0 +1,34 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * minecraft_fetch_lightmap(Sampler2, UV2);
+    texCoord0 = UV0;
+    texCoord1 = UV1;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_alpha.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_alpha.vsh
@@ -1,0 +1,27 @@
+#version 150
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in vec2 UV2;
+in vec3 Normal;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec2 texCoord2;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexColor = Color;
+    texCoord0 = UV0;
+    texCoord1 = UV1;
+    texCoord2 = UV2;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout.vsh
@@ -1,0 +1,37 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = minecraft_fetch_lightmap(Sampler2, UV2);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull.vsh
@@ -1,0 +1,41 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main ()
+{
+	gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+	vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+	vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+
+	//lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
+	lightMapColor = minecraft_fetch_lightmap(Sampler2, UV2);
+
+	overlayColor = texelFetch(Sampler1, UV1, 0);
+	texCoord0 = UV0;
+	normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_cutout_no_cull_z_offset.vsh
@@ -1,0 +1,37 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = minecraft_fetch_lightmap(Sampler2, UV2);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_decal.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_decal.vsh
@@ -1,0 +1,35 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * minecraft_fetch_lightmap(Sampler2, UV2);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_no_outline.vsh
@@ -1,0 +1,32 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main ()
+{
+	gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+	vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+	vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * minecraft_fetch_lightmap(Sampler2, UV2);
+	texCoord0 = UV0;
+	normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_shadow.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_shadow.vsh
@@ -1,0 +1,20 @@
+#version 150
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = Color;
+    texCoord0 = UV0;
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_smooth_cutout.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_smooth_cutout.vsh
@@ -1,0 +1,37 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = minecraft_fetch_lightmap(Sampler2, UV2);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_solid.vsh
@@ -1,0 +1,35 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec4 normal;
+
+void main ()
+{
+	gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+	vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+	vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * minecraft_fetch_lightmap(Sampler2, UV2);
+	texCoord0 = UV0;
+	texCoord1 = UV1;
+	normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_translucent.vsh
@@ -1,0 +1,37 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = minecraft_fetch_lightmap(Sampler2, UV2);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_entity_translucent_cull.vsh
@@ -1,0 +1,36 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in vec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec2 texCoord1;
+out vec2 texCoord2;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color) * minecraft_fetch_lightmap(Sampler2, UV2);
+    texCoord0 = UV0;
+    texCoord1 = UV1;
+    texCoord2 = UV2;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_leash.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_leash.vsh
@@ -1,0 +1,23 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in ivec2 UV2;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform vec4 ColorModulator;
+
+out float vertexDistance;
+flat out vec4 vertexColor;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = Color * ColorModulator * minecraft_fetch_lightmap(Sampler2, UV2);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_text.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_text.vsh
@@ -1,0 +1,25 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec2 texCoord0;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexDistance = length((ModelViewMat * vec4(Position, 1.0)).xyz);
+    vertexColor = Color * minecraft_fetch_lightmap(Sampler2, UV2);
+    texCoord0 = UV0;
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_translucent_moving_block.vsh
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/core/rendertype_translucent_moving_block.vsh
@@ -1,0 +1,26 @@
+#version 150
+
+#moj_import <light.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out vec4 vertexColor;
+out vec2 texCoord0;
+out vec4 normal;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+
+    vertexColor = Color * minecraft_fetch_lightmap(Sampler2, UV2);
+    texCoord0 = UV0;
+    normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
+}

--- a/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/include/light.glsl
+++ b/golden-days-base/assets/minecraft/golden-days-base/assets/minecraft/shaders/include/light.glsl
@@ -1,0 +1,72 @@
+#version 150
+
+const float MINECRAFT_LIGHT_POWER   = 0.6;
+const float MINECRAFT_AMBIENT_LIGHT = 0.4;
+
+vec4 minecraft_mix_light(vec3 lightDir0, vec3 lightDir1, vec3 normal, vec4 color) {
+	lightDir0 = normalize(lightDir0);
+	lightDir1 = normalize(lightDir1);
+	float light0 = max(0.0, dot(lightDir0, normal));
+	float light1 = max(0.0, dot(lightDir1, normal));
+	float lightAccum = min(1.0, (light0 + light1) * MINECRAFT_LIGHT_POWER + MINECRAFT_AMBIENT_LIGHT);
+	return vec4(color.rgb * lightAccum, color.a);
+}
+
+const float LIGHT_UV_MIN = 0.5  / 16.0;
+const float LIGHT_UV_MAX = 15.5 / 16.0;
+const vec3  LUMA_REC601 = vec3(0.299, 0.587, 0.114);
+
+const float[] LIGHT_LUT = float[](
+	0.04705882, 0.06274509, 0.08235294, 0.10196078,
+	0.12549019, 0.15294117, 0.18431372, 0.21960784,
+	0.25882352, 0.30588235, 0.36470588, 0.43529411,
+	0.52156862, 0.63529411, 0.78823529, 1.0
+);
+
+const float[] BLOCKLIGHT_LUT = float[](
+	0.06274509, 0.08235294, 0.10980392, 0.13333333,
+	0.16470588, 0.2,        0.24313725, 0.28627450,
+	0.33725490, 0.39215686, 0.46274509, 0.54117647,
+	0.62745098, 0.72941176, 0.85098039, 1.0
+);
+
+const bool USE_INCREMENTAL_DAYLIGHT = false;
+
+
+vec4 get_light_lut_value (vec4 bl, vec4 sl, ivec2 uv)
+{
+	float bl_g = dot(bl.rgb, LUMA_REC601) * LIGHT_LUT[uv.x >> 4];
+	float sl_g = dot(sl.rgb, LUMA_REC601) * BLOCKLIGHT_LUT[uv.y >> 4];
+
+	// if (USE_INCREMENTAL_DAYLIGHT)
+	// {
+	// 	sl_g = floor(sl_g * 8.) / 8.;
+	// }
+
+	return vec4(
+		vec3(max(bl_g, sl_g)),
+		max(bl.a, sl.a)
+	);
+}
+
+
+vec4 minecraft_sample_lightmap (sampler2D lightMap, ivec2 uv)
+{
+	vec4 sl = texture(lightMap, vec2(LIGHT_UV_MIN, LIGHT_UV_MAX));
+	vec4 bl = texture(lightMap, vec2(LIGHT_UV_MAX, LIGHT_UV_MIN));
+
+	return get_light_lut_value(bl, sl, uv);
+	//return texture(lightMap, clamp(uv / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0)));
+}
+
+
+vec4 minecraft_fetch_lightmap (sampler2D lightMap, ivec2 uv)
+{
+	vec4 sl = texelFetch(lightMap, ivec2(0, 15), 0);
+	vec4 bl = texelFetch(lightMap, ivec2(15, 0), 0);
+
+	return get_light_lut_value(bl, sl, uv);
+}
+
+
+


### PR DESCRIPTION
Admittedly, the way I did this is a bit hacky, since the light texture is still by the game generated internally every frame, so I manually created my own lookup table and multiply the result of that by the highest block and skylight values in the light texture (so day/night still work correctly). 

Also, the blocklight is not 1:1 like skylight is (they should be the same), as I felt it was *too* dark when inside. This might be due to default gamma settings changing between 1.7.3 and below vs 1.8 and above. If you want to use the accurate skylight, change any references to `BLOCKLIGHT_LUT` in `shaders/include/light.glsl` with `LIGHT_LUT`.

Let me know if I missed any shaders that have a light texture lookup (usually using `texelfetch`). I think I found all instances of this but I could be wrong.

Additionally, my shader code here probably isn't the fastest (due to that dynamic array access). I can't do a whole lot about that, like I said, the light table is still generated internally rather than in a shader (despite the fact that, aside from how the flicker is done, it is PRIME real estate for being created in a shader. RIP).

Could also be worth splitting this off into its own resource pack module, for people who actually do like the tinted+flickering lighting.

Edit: Upon further thinking shaders could 100% be used to implement classic-looking lighting for skylight. I don't think there would be much of a *point* to doing so but for the sake of completeness it can be done.